### PR TITLE
Add total cost calculation for cart items

### DIFF
--- a/src/cart/index.html
+++ b/src/cart/index.html
@@ -90,6 +90,10 @@
             <p class="cart-card__price">$199.99</p>
           </li> -->
         </ul>
+        <div class="cart-footer hide">
+          <p class="cart-total">Total: $<span id="cart-total-amount"></span></p>
+        </div>
+        
       </section>
     </main>
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -202,6 +202,10 @@ button {
   grid-column: 3;
 }
 
+.hide {
+  display: none;
+}
+
 @media screen and (min-width: 500px) {
   body {
     max-width: 1080px;

--- a/src/js/cart.js
+++ b/src/js/cart.js
@@ -1,7 +1,6 @@
 import { getLocalStorage } from "./utils.mjs";
 
-// Gets the content in the local storage which can be an object ( key value pair)
-// or an array of objects and creates carts.
+
 function renderCartContents() {
   const cartItems = getLocalStorage("so-cart") || [];
   const htmlItems = cartItems.map((item) => cartItemTemplate(item));
@@ -20,11 +19,27 @@ function cartItemTemplate(item) {
     <h2 class="card__name">${item.Name}</h2>
   </a>
   <p class="cart-card__color">${item.Colors[0].ColorName}</p>
-  <p class="cart-card__quantity">qty: 1</p>
-  <p class="cart-card__price">$${item.FinalPrice}</p>
+  <p class="cart-card__quantity">qty: 1</p> <!-- Fijo en 1 -->
+  <p class="cart-card__price">$${item.FinalPrice.toFixed(2)}</p>
 </li>`;
 
   return newItem;
 }
 
 renderCartContents();
+
+document.addEventListener('DOMContentLoaded', () => {
+  const cartItems = getLocalStorage("so-cart") || [];
+  const cartFooter = document.querySelector('.cart-footer');
+  const cartTotalAmount = document.getElementById('cart-total-amount');
+
+  if (cartItems.length > 0) {
+    cartFooter.classList.remove('hide');
+    const total = cartItems.reduce((sum, item) => {
+      const price = parseFloat(item.FinalPrice) || 0;
+      return sum + price; 
+    }, 0);
+    cartTotalAmount.textContent = total.toFixed(2);
+  }
+  
+});


### PR DESCRIPTION
This pull request adds the functionality to calculate and display the total cost of items in the cart. The total is shown only when the cart is not empty. Changes include updates to HTML, CSS, and JavaScript